### PR TITLE
Replace swagger codegen with redoc cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ ENV AWSCLI_VERSION='1.18.93'
 
 RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION}
 RUN apk add openjdk11
-RUN wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.20/swagger-codegen-cli-3.0.20.jar -O swagger-codegen-cli.jar
-
-ENTRYPOINT ["/entrypoint.sh"]
+RUN apk add nodejs nodejs-npm
+RUN npm install -g redoc-cli@0.9.10
 
 COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,16 +39,15 @@ if [[ $INPUT_RESOURCE_TYPE == 'SWAGGER_TO_HTML' ]]; then
   if [[ -f "$INPUT_SOURCE_PATH" ]]; then
     echo "Source path must be a directory for the resource type SWAGGER_TO_HTML"
     exit 1
-  fi 
+  fi
   SWAGGER_SPECIFICATION_FILES=$(ls $INPUT_SOURCE_PATH/*.yml)
   for SWAGGER_SPECIFICATION_FILE in $SWAGGER_SPECIFICATION_FILES
   do
     echo "Generating html docs for: $SWAGGER_SPECIFICATION_FILE"
     SWAGGER_SPECIFICATION_FILE_NAME="$(basename -- $SWAGGER_SPECIFICATION_FILE)"
-    java -jar /swagger-codegen-cli.jar generate \
-         -i $SWAGGER_SPECIFICATION_FILE \
-         -l html2 \
-         -o "/tmp/${SWAGGER_SPECIFICATION_FILE_NAME%.*}"  
+    redoc-cli bundle \
+          $SWAGGER_SPECIFICATION_FILE \
+          -o "/tmp/${SWAGGER_SPECIFICATION_FILE_NAME%.*}"
   done
   INPUT_SOURCE_PATH=/tmp
   DESTINATION_PATH=swagger-docs
@@ -58,7 +57,7 @@ if [[ $INPUT_RESOURCE_TYPE == 'TEST_COVERAGE' ]]; then
   if [[ -f "$INPUT_SOURCE_PATH" ]]; then
     echo "Source path must be a directory for the resource type TEST_COVERAGE"
     exit 1
-  fi 
+  fi
   DESTINATION_PATH=test-coverage
 fi
 
@@ -67,7 +66,7 @@ fi
 sh -c "aws s3 cp ${INPUT_SOURCE_PATH} s3://${INPUT_AWS_S3_BUCKET_NAME}/${REPO_NAME}/${DESTINATION_PATH} \
         --profile upload-artifacts-profile \
         --no-progress \
-        --metadata $METADATA $ARGS" 
+        --metadata $METADATA $ARGS"
 
 aws configure --profile upload-artifacts-profile <<-EOF > /dev/null 2>&1
 null


### PR DESCRIPTION
Proposing replacing the use of swagger-codegen with redoc-cli to produce the static HTML from a OpenAPI spec file.

**How generated HTML looks from swagger-codegen**
![screencapture-file-Users-akraminakib-Downloads-index-html-2020-08-22-23_26_34](https://user-images.githubusercontent.com/17439993/90970175-5db92780-e4cf-11ea-980a-0072830beb39.png)

**How HTML produced from redoc-cli would look with the same spec file**
![screencapture-file-Users-akraminakib-Downloads-openapi-html-2020-08-22-23_28_02](https://user-images.githubusercontent.com/17439993/90970181-6c9fda00-e4cf-11ea-971a-ded40b23788d.png)

