### PR TITLE
replace / with - in branch names

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,8 @@ ${INPUT_AWS_REGION}
 text
 EOF
 
-BRANCH_NAME=$(echo $GITHUB_REF | cut -d'/' -f 3)
+REF_ARR=(${GITHUB_REF//// })
+BRANCH_NAME=$(echo "${REF_ARR[@]:2}" | tr ' ' -)
 REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d'/' -f 2)
 METADATA="{\\\"initiator\\\":\\\"$GITHUB_ACTOR\\\",\\\"commit_sha\\\":\\\"$GITHUB_SHA\\\"}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ ${INPUT_AWS_REGION}
 text
 EOF
 
-REF_ARR=(${GITHUB_REF//// })
+REF_ARR=($(echo $GITHUB_REF | sed -e "s/\// /g"))
 BRANCH_NAME=$(echo "${REF_ARR[@]:2}" | tr ' ' -)
 REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d'/' -f 2)
 METADATA="{\\\"initiator\\\":\\\"$GITHUB_ACTOR\\\",\\\"commit_sha\\\":\\\"$GITHUB_SHA\\\"}"


### PR DESCRIPTION
1. refs/heads/master
2. refs/heads/feature/foo
3. refs/heads/feature/foo/bar/...

For refs 2 and 3, incorrect object keys will be created in s3
/ is used for the hierarchy of subfolders, so the solution is to replace / with -

For `refs/heads/feature/foo`
Before: bucket/.../feature/72.zip
This PR: bucket/.../feature-foo/72.zip

For `refs/heads/feature/foo/bar`
Before: bucket/.../feature/72.zip
This PR: bucket/.../feature-foo-bar/72.zip

